### PR TITLE
シークバーの操作

### DIFF
--- a/client/components/containers/player/PreviousButton.vue
+++ b/client/components/containers/player/PreviousButton.vue
@@ -50,26 +50,26 @@ export default Vue.extend({
 
   methods: {
     onPreivousClicked() {
+      // 前の曲がない場合はすぐに先頭から再生
+      if (this.disabledSkippingPrev) {
+        this.$dispatch('playback/seek', { positionMs: 0 });
+        return;
+      }
+
       // 初めにクリックされてから1秒以内に再度クリックされたら前の曲に戻る
       if (this.firstClicked) {
-        console.log('double');
         if (this.previousTimer != null) {
           clearTimeout(this.previousTimer);
           this.previousTimer = undefined;
         }
-        // 二回クリックされても前の曲がなければ 0:00 から再生
-        if (this.disabledSkippingPrev) {
-          this.$dispatch('playback/seek', { positionMs: 0 });
-        } else {
-          this.$dispatch('playback/previous');
-        }
+        this.$dispatch('playback/previous');
       } else {
         this.firstClicked = true;
         setTimeout(() => {
           this.firstClicked = false;
         }, 1000);
 
-        // 二回目のクリックがないか 400ms は待ってキャンセルされなければ(とりあえず) 0:00 から再生
+        // 二回目のクリックがないか 400ms は待ってキャンセルされなければ(とりあえず) 先頭から再生
         this.previousTimer = setTimeout(() => {
           this.$dispatch('playback/seek', { positionMs: 0 });
           this.previousTimer = undefined;

--- a/client/store/playback/actions.ts
+++ b/client/store/playback/actions.ts
@@ -377,13 +377,18 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
   },
 
   async seek({
-    state, getters, commit, dispatch,
+    state,
+    getters,
+    commit,
+    dispatch,
   }, { positionMs, currentPositionMs }) {
     const isAuthorized = await dispatch('auth/confirmAuthState', undefined, { root: true });
     if (!isAuthorized) return;
 
     if (getters.isDisallowed('seeking')) return;
 
+    // Playback SDK からの通知が来ない場合が偶にあるので先に変更しておく
+    commit('SET_POSITION_MS', positionMs);
     const positionMsOfCurrentState = state.positionMs;
 
     await this.$spotify.player.seek({ positionMs })


### PR DESCRIPTION
## About

- close #387 
  - 他のデバイスでエピソード再生中などの時にアイテムが取得できないときはシークバー操作できないようにする
- close #390
  - `/seek` リクエストする前に表示を先に変えとく
- ダブルクリックして前の曲を再生するときに一瞬先頭から再生されちゃうのを防ぐ